### PR TITLE
Prevent NULL being returned for getRules() calls

### DIFF
--- a/Source/SampQueryAPI.php
+++ b/Source/SampQueryAPI.php
@@ -279,7 +279,7 @@ class SampQueryAPI
 		fread($this->rSocket, 11);
 		
 		$iRuleCount = ord(fread($this->rSocket, 2));
- 		$aReturn = array();
+ 		$aDetails = array();
 		
 		for($iIndex = 0; $iIndex < $iRuleCount; ++$iIndex)
 		{


### PR DESCRIPTION
`PHP Notice: Undefined variable: aDetails in SampQueryAPI.php on line 292`

`$aDetails` is now initialized as an empty array, so this shouldn't happen.
